### PR TITLE
Fix for crash issue that results in freezing of the GUI when the log exceeds 1000 lines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ If it fixes a bug or resolves a feature request, be sure to link to that issue.
 
 ## Types of changes
 
-What types of changes does your code introduce to Appium?
+What types of changes does your code introduce to PyPeCT2S?
 _Put an `x` in the boxes that apply_
 
 - [ ] Bugfix (non-breaking change which fixes an issue)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,5 +30,5 @@ keywords:
   - bone
   - python
 license: GPL-3.0-or-later
-version: 1.0.2
-date-released: '2024-08-19'
+version: 1.0.3
+date-released: '2024-08-20'

--- a/core_libs/texteditredirector.py
+++ b/core_libs/texteditredirector.py
@@ -65,9 +65,11 @@ class TextEditRedirector:
             # Remove lines at the beginning if we have too many lines
             while self.log_text_edit.document().blockCount() > self.max_lines:
                 cursor.movePosition(QTextCursor.MoveOperation.Start)  # Move the cursor to the start of the text edit
-                cursor.select(QTextCursor.SelectionType.LineUnderCursor)  # Select the line under the cursor
+                cursor.select(QTextCursor.SelectionType.BlockUnderCursor)  # Select the line under the cursor
                 cursor.removeSelectedText()  # Remove the selected text
+                cursor.deleteChar()  # Ensure the block is completely removed
 
+            cursor.movePosition(QTextCursor.MoveOperation.End)
             self.log_text_edit.setTextCursor(cursor)  # Set the text
             self.log_text_edit.ensureCursorVisible()  # Ensure the cursor is visible
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog:
 
+## 1.0.3
+
+- Fixed issue with log window; where if the window exceeded 1000 lines it would freeze the program until it was 
+restarted. Now it will remove lines from the top of the log window if it exceeds 1000 lines.
+
 ## 1.0.2
 
 - Fixed issue in meshing script where it would look for a temporary file that it did not need to unless certain


### PR DESCRIPTION
## Proposed changes

Fixes the bug that causes the GUI to freeze completely when the log window exceeds 1000 lines, as the function responsible was missing lines to make it function correctly.

Resolves issue #3 

## Types of changes

What types of changes does your code introduce to PyPeCT2S?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Other/additional information or context to your pull request:
n/a

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of 
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before 
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/INSIGNEO/PyPeCT2S/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have tested the code locally
- [x] I have added the necessary documentation (if appropriate)

## Further comments

n/a